### PR TITLE
Fix hardcoded fhir-concept index name to use indexPrefix

### DIFF
--- a/src/main/java/org/snomed/snowstorm/config/Config.java
+++ b/src/main/java/org/snomed/snowstorm/config/Config.java
@@ -309,12 +309,13 @@ public abstract class Config extends ElasticsearchConfig {
 
 	protected void updateIndexMappingFieldsLimitSetting() {
 		try {
-			Request updateSettingsRequest = new Request("PUT", "/fhir-concept/_settings");
+			String indexName = indexNameProvider().indexName("fhir-concept");
+			Request updateSettingsRequest = new Request("PUT", "/" + indexName + "/_settings");
 			updateSettingsRequest.setJsonEntity("{\"" + INDEX_MAX_FIELDS_LIMIT + "\": " + indexMaxFieldsLimit + "}");
 			elasticsearchRestClient(clientConfiguration()).performRequest(updateSettingsRequest);
-			logger.info("{} is updated to {}", INDEX_MAX_FIELDS_LIMIT, indexMaxFieldsLimit);
+			logger.info("{} is updated to {} for {}", INDEX_MAX_FIELDS_LIMIT, indexMaxFieldsLimit, indexName);
 		} catch (IOException e) {
-			logger.error("Failed to update setting {}", INDEX_MAX_TERMS_COUNT, e);
+			logger.error("Failed to update setting {} on index fhir-concept", INDEX_MAX_FIELDS_LIMIT, e);
 		}
 	}
 }


### PR DESCRIPTION
## Summary
Fix the `updateIndexMappingFieldsLimitSetting` method in `Config.java` to properly use the configured index prefix when updating Elasticsearch settings for the fhir-concept index.

## Issue
The method was using a hardcoded index name `/fhir-concept/_settings` instead of using the `indexNameProvider`, which caused failures when a custom index prefix is configured.

**Error behavior:**
When `elasticsearch.index.prefix` is set (e.g., to `atticus-`), the method would try to update settings on `fhir-concept` instead of `atticus-fhir-concept`, resulting in index not found errors.

## Solution
- Use `indexNameProvider().indexName("fhir-concept")` to get the correctly prefixed index name
- Update log messages to include the actual index name being operated on
- Fix error log to correctly reference `INDEX_MAX_FIELDS_LIMIT` instead of `INDEX_MAX_TERMS_COUNT`

## Changes
**File**: `src/main/java/org/snomed/snowstorm/config/Config.java`
- Line 312: Added `String indexName = indexNameProvider().indexName("fhir-concept");`
- Line 313: Changed `/fhir-concept/_settings` to `"/" + indexName + "/_settings"`
- Line 316: Updated log to include index name
- Line 318: Fixed error log message

## Test plan
- [ ] Verify application starts with a custom index prefix configured
- [ ] Check logs show correct prefixed index name when updating settings
- [ ] Confirm no "index not found" errors for fhir-concept operations
- [ ] Test FHIR functionality works correctly with prefixed indices

🤖 Generated with [Claude Code](https://claude.com/claude-code)